### PR TITLE
Add permission.read permission for member and old member

### DIFF
--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -79,6 +79,7 @@ member_permission_map = {
   'form/open_question' => %i[create read],
   'form/closed_question_answer' => %i[create read],
   'form/open_question_answer' => %i[create read],
+  'permission' => [:read],
   'static_page' => %i[read],
   'debit/collection' => %i[read],
   'debit/transaction' => []
@@ -108,6 +109,7 @@ old_members_permission_map = {
   'form/open_question' => %i[read],
   'form/closed_question_answer' => %i[read],
   'form/open_question_answer' => %i[read],
+  'permission' => [:read],
   'static_page' => %i[read]
 }
 


### PR DESCRIPTION
### Summary
This PR add the permission.read permission for member and old member group. Since a recent update of the jsonapi_authorization gem the permissions are needed to fetch related resources. Permission is a related resource of a user and should be fetchable. 