### PR TITLE
Add to address for SMTP mail

### DIFF
--- a/app/mailers/mail_smtp_mailer.rb
+++ b/app/mailers/mail_smtp_mailer.rb
@@ -2,13 +2,13 @@ class MailSMTPMailer < ApplicationMailer
   def enabled_email(mail_alias, password)
     @mail_alias = mail_alias
     @password = password
-    mail cc: 'mailbeheer@csvalpha.nl', bcc: mail_alias.mail_addresses,
+    mail to: 'mailbeheer@csvalpha.nl', bcc: mail_alias.mail_addresses,
          subject: "SMTP account voor #{mail_alias.email} aangemaakt"
   end
 
   def disabled_email(mail_alias)
     @mail_alias = mail_alias
-    mail cc: 'mailbeheer@csvalpha.nl', bcc: mail_alias.mail_addresses,
+    mail to: 'mailbeheer@csvalpha.nl', bcc: mail_alias.mail_addresses,
          subject: "SMTP account voor #{mail_alias.email} opgeheven"
   end
 end

--- a/spec/jobs/smtp_job_spec.rb
+++ b/spec/jobs/smtp_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SMTPJob, type: :job do
 
       it { expect(mailgun_client).to have_received(:post) }
       it { expect(mail.bcc).to eq mail_alias.mail_addresses }
-      it { expect(mail.cc).to eq ['mailbeheer@csvalpha.nl'] }
+      it { expect(mail.to).to eq ['mailbeheer@csvalpha.nl'] }
       it { expect(mail.subject).to eq "SMTP account voor #{mail_alias.email} aangemaakt" }
     end
 
@@ -40,7 +40,7 @@ RSpec.describe SMTPJob, type: :job do
 
       it { expect(mailgun_client).to have_received(:delete) }
       it { expect(mail.bcc).to eq mail_alias.mail_addresses }
-      it { expect(mail.cc).to eq ['mailbeheer@csvalpha.nl'] }
+      it { expect(mail.to).to eq ['mailbeheer@csvalpha.nl'] }
       it { expect(mail.subject).to eq "SMTP account voor #{mail_alias.email} opgeheven" }
     end
   end


### PR DESCRIPTION
### Summary
Mailgun doesn't like it when you only specify a bcc and a cc . Mailcatcher doens't care about this, so didn't see this issue when developing. This PR fixes this issue for the SMTP mailer.