### PR TITLE
Hotfix doorkeeper oauth error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (5.2.2)
+    doorkeeper (5.1.0)
       railties (>= 5)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)


### PR DESCRIPTION
### Summary
This is a hotfix for the broken doorkeeper oauth verification. It failed with the following error:
`translation missing: nl.doorkeeper.errors.messages.invalid_request.missing_param`
More people seem to have this issue when upgrading doorkeeper to 5.2 from 5.1 (https://github.com/doorkeeper-gem/doorkeeper/issues/1307). Rolling back to doorkeeper 5.1 fixes the issue for now.