### PR TITLE
Do not leak whole User objects in email subject line

### DIFF
--- a/app/mailers/user_cleanup_mailer.rb
+++ b/app/mailers/user_cleanup_mailer.rb
@@ -2,7 +2,7 @@ class UserCleanupMailer < ApplicationMailer
   def cleanup_email(will_archive_users, archived_users)
     @will_archive_users = will_archive_users
     @archived_users = archived_users
-    subject = "[Belangrijk!] #{@will_archive_users} Alpha accounts"\
+    subject = "[Belangrijk!] #{@will_archive_users.count} Alpha accounts"\
               ' staan op het punt gearchiveerd te worden'
     subject = 'Er zijn gebruikers gearchiveerd!' if @will_archive_users.empty?
 


### PR DESCRIPTION
Prevents leaking User objects into the subject line. Including partial password-digest and iCal secret key.