### PR TITLE
Render OTP QR client side

### DIFF
--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -3,7 +3,7 @@ class V1::UsersController < V1::ApplicationController # rubocop:disable Metrics/
   before_action :doorkeeper_authorize!, except: %i[activate_account reset_password
                                                    get_related_resource]
   before_action :set_model, only: %i[update archive activate_account
-                                     resend_activation_mail generate_otp_provisioning_uri
+                                     resend_activation_mail generate_otp_secret
                                      activate_otp activate_webdav]
 
   def update
@@ -56,7 +56,7 @@ class V1::UsersController < V1::ApplicationController # rubocop:disable Metrics/
     head :no_content
   end
 
-  def generate_otp_provisioning_uri
+  def generate_otp_secret
     authorize @model
 
     if @model.otp_required?
@@ -64,8 +64,9 @@ class V1::UsersController < V1::ApplicationController # rubocop:disable Metrics/
                     status: :unprocessable_entity
     end
 
-    qrcode = RQRCode::QRCode.new(regenerate_otp_provisioning_uri!)
-    render json: { data_url: qrcode.as_png(size: 240).to_data_url }
+    uri = regenerate_otp_provisioning_uri!
+    qrcode = RQRCode::QRCode.new(uri)
+    render json: { data_url: qrcode.as_png(size: 240).to_data_url, otp_code: uri }
   end
 
   def activate_otp

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -33,7 +33,7 @@ class UserPolicy < ApplicationPolicy
     create?
   end
 
-  def generate_otp_provisioning_uri?
+  def generate_otp_secret?
     me?
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
         post :activate_account
         post :archive
         post :resend_activation_mail
-        post :generate_otp_provisioning_uri
+        post :generate_otp_secret
         post :activate_otp
         post :activate_webdav
       end

--- a/spec/requests/v1/users_controller/generate_otp_secret_spec.rb
+++ b/spec/requests/v1/users_controller/generate_otp_secret_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe V1::UsersController do
-  describe 'GET /users/:id/generate_otp_provisioning_uri', version: 1 do
+  describe 'GET /users/:id/generate_otp_secret', version: 1 do
     let(:record) { FactoryBot.create(:user) }
-    let(:record_url) { "/v1/users/#{record.id}/generate_otp_provisioning_uri" }
+    let(:record_url) { "/v1/users/#{record.id}/generate_otp_secret" }
 
     subject(:request) { post(record_url) }
 


### PR DESCRIPTION
### Summary
Currently we render the QR image on the server. However, this results in a data string which we cannot render on the UI due to the CSP. We do not want to allow this, since this can give security issues. This PR changes the endpoint to return the secret such that the UI can build the QR code itself.