### PR TITLE
Always ensure pidfile path is present

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -22,7 +22,6 @@ pidfile = ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 # Ensure that the pidfile path exists
 Pathname(pidfile).dirname.mkpath
 
-
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
 # the concurrency of the application would be max `threads` * `workers`.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,11 @@ port        ENV.fetch('PORT') { 3000 }
 environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
+pidfile = ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
+
+# Ensure that the pidfile path exists
+Pathname(pidfile).dirname.mkpath
+
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
   redis:
     env_file: .env
-    image: 'redis:3.2-alpine'
+    image: 'redis:5.0-alpine'
     command: redis-server --requirepass ${REDIS_PASSWORD}
     volumes:
       - redis_data:/var/lib/redis/data


### PR DESCRIPTION
Currently puma failes on the fact that `./tmp/pids` does not exists. This PR adds a bit of code to always ensure that the path is present such that puma can write its pids there