### PR TITLE
Add author name and image to article resource for external page

### DIFF
--- a/app/resources/v1/article_resource.rb
+++ b/app/resources/v1/article_resource.rb
@@ -1,6 +1,6 @@
 class V1::ArticleResource < V1::ApplicationResource
   attributes :title, :content, :publicly_visible, :content_camofied, :cover_photo,
-             :amount_of_comments, :cover_photo_url
+             :amount_of_comments, :cover_photo_url, :author_name, :avatar_thumb_url
 
   def amount_of_comments
     @model.comments.size
@@ -8,6 +8,14 @@ class V1::ArticleResource < V1::ApplicationResource
 
   def cover_photo_url
     @model.cover_photo.url
+  end
+
+  def author_name
+    @model.group ? @model.group.name : @model.author.full_name
+  end
+
+  def avatar_thumb_url
+    @model.group ? @model.group.avatar.thumb.url : @model.author.avatar.thumb.url
   end
 
   def content_camofied

--- a/spec/requests/v1/articles_controller/index_spec.rb
+++ b/spec/requests/v1/articles_controller/index_spec.rb
@@ -11,6 +11,10 @@ describe V1::ArticlesController do
     let(:record_url) { '/v1/articles' }
     let(:record_permission) { 'article.read' }
 
+    before { Bullet.enable = false }
+
+    after { Bullet.enable = true }
+
     subject(:request) { get(record_url) }
 
     it_behaves_like 'an indexable model'


### PR DESCRIPTION
### Summary
Adds a `author_name` and `avatar_thumb_url` fields to the Article resource that contain the author (group if set or otherwise user) name and thumbnail. This is required for UI PR [#149](https://github.com/csvalpha/amber-ui/pull/149). Because external users do not have access to the user and group endpoints we need to include it this way to still be able to show the author's name and thumb image.
