### PR TITLE
Hash user and application tokens

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -5,6 +5,9 @@ Doorkeeper.configure do # rubocop:disable Metrics/BlockLength
   api_only
   use_refresh_token
 
+  hash_token_secrets
+  hash_application_secrets fallback: :plain
+
   optional_scopes :tomato
 
   # See https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Resource-Owner-Password-Credentials-flow

--- a/spec/support/contexts/requests/when_authenticated.rb
+++ b/spec/support/contexts/requests/when_authenticated.rb
@@ -3,6 +3,6 @@ shared_context 'when authenticated' do
   let(:access_token) { Doorkeeper::AccessToken.create!(resource_owner_id: user.id) }
 
   before do
-    header('Authorization', "Bearer #{access_token.token}")
+    header('Authorization', "Bearer #{access_token.plaintext_token}")
   end
 end


### PR DESCRIPTION
### Summary
This PR adds the hashing of the doorkeeper tokens. This prevents the leak of those tokens to be useable. I did not include the fallback for users (since they can simply logout and login again). For Sofia the plaintext fallback is added. After this PR is merged we should create a new doorkeeper application (which has a hashed secret) and then we can remove this fallback.

Ref: https://doorkeeper.gitbook.io/guides/security/token-and-application-secrets
Fixes #152
