### PR TITLE
Update SMTP server url

### DIFF
--- a/app/views/mail_smtp_mailer/enabled_email.erb
+++ b/app/views/mail_smtp_mailer/enabled_email.erb
@@ -7,7 +7,7 @@ Voor Gmail doet u dat op de volgende manier:<br/><br/>
 3. Klik onder 'Mail verzenden als' op 'Nog een e-mailadres toevoegen)<br/>
 4. Veranderd de naam naar Naam || Functie (dus bijvoorbeeld Jan Hendrik || Mailbeheer der C.S.V. Alpha) en voer het onderstaande e-mailadres in.<br/>
 5. Klik op volgende<br/>
-6. Voer bij 'SMTP-Server' het volgende in: 'smtp.csvalpha.nl'<br/>
+6. Voer bij 'SMTP-Server' het volgende in: 'smtp.eu.mailgun.org'<br/>
 7. Voer bij gebruikersnaam het e-mailadres in<br/>
 8. Voer als wachtwoord het onderstaande wachtwoord in<br/>
 9. Wacht op de verficatiecode en voer deze in<br/>


### PR DESCRIPTION
The Alpha mail server alias no longer works correctly so we want to ask users to use the mailgun url instead.
