### PR TITLE
Fix doorkeeper token lookup

### DIFF
--- a/config/initializers/message_bus.rb
+++ b/config/initializers/message_bus.rb
@@ -9,7 +9,7 @@ end
 MessageBus.group_ids_lookup do |env|
   if env['HTTP_AUTHORIZATION']
     access_token = env['HTTP_AUTHORIZATION'].split(' ').last
-    if Doorkeeper::AccessToken.find_by(token: access_token)
+    if Doorkeeper::AccessToken.by_token(access_token)
       [0] # use group 0 as global group for all authenticated users
     end
   end

--- a/lib/auth_constraint.rb
+++ b/lib/auth_constraint.rb
@@ -5,7 +5,7 @@ class AuthConstraint
     token = JSON.parse(request.cookie_jar['ember_simple_auth-session']).dig('authenticated',
                                                                             'access_token')
     Rails.cache.fetch(token, expires_in: 1.minute) do
-      user_id = Doorkeeper::AccessToken.find_by(token: token).resource_owner_id
+      user_id = Doorkeeper::AccessToken.by_token(token).resource_owner_id
       User.sidekiq_access.login_enabled.exists?(user_id)
     end
   end

--- a/spec/lib/auth_constraint_spec.rb
+++ b/spec/lib/auth_constraint_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AuthConstraint do
         OpenStruct.new(cookie_jar: {
                          'ember_simple_auth-session' => JSON.generate(
                            'authenticated' => {
-                             'access_token' => access_token[:token]
+                             'access_token' => access_token.plaintext_token
                            }
                          )
                        })


### PR DESCRIPTION
### Summary
Currently we do a token lookup on 2 places to check if a user is authenticated. However, we use the plaintext token (which the user has) and compare that with the database. However, the database contains a hashed version, resulting in no match. Doorkeeper::AccessToken has a special `by_token` method which should be used and is fixed in this PR