### PR TITLE
Forgot another encoding

### DIFF
--- a/app/models/import/transaction.rb
+++ b/app/models/import/transaction.rb
@@ -31,7 +31,7 @@ module Import
 
     def read_csv(file_path)
       transactions_to_save = []
-      CSV.foreach(file_path, headers: true, col_sep: ',', encoding: 'ISO-8859-1') do |row|
+      CSV.foreach(file_path, headers: true, col_sep: ',', encoding: 'bom|utf-8') do |row|
         transactions_to_save.push(*row_to_transactions(row))
       end
       transactions_to_save


### PR DESCRIPTION
Upload of a debit collection now completes succesfully. Tested this with a debit collection CSV that includes a BOM. The file I now tested with contained one transaction, for a valid username. Previous commit, the last test I performed was with a file that did not include valid transactions.

### Summary
fixes #183