### PR TITLE
add displayName for NC groups

### DIFF
--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -159,6 +159,6 @@ class V1::UsersController < V1::ApplicationController # rubocop:disable Metrics/
   end
 
   def nextcloud_groups
-    current_user.active_groups.map(&:id).join(',')
+    current_user.active_groups.map { |g| { gid: g.id, displayName: g.name } }
   end
 end

--- a/spec/requests/v1/users_controller/nextcloud_spec.rb
+++ b/spec/requests/v1/users_controller/nextcloud_spec.rb
@@ -22,7 +22,8 @@ describe V1::UsersController do
         it { expect(json['id']).to eq user.id }
         it { expect(json['displayName']).to eq user.full_name }
         it { expect(json['email']).to eq user.email }
-        it { expect(json['groups']).to eq group.id.to_s }
+        it { expect(json['groups'][0]['gid']).to eq group.id }
+ 	      it { expect(json['groups'][0]['displayName']).to eq group.name }
       end
     end
   end


### PR DESCRIPTION
There will be support for setting displayNames in the next release of social-login. This makes our nextcloud endpoint also provide the displayNames. The nice thing about it is that we no longer have groups like `alpha-12` but it will just be the group name itself.