### PR TITLE
Fix papertrail destroying on archiving user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,9 +184,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.last_name = id
     self.login_enabled = false
     self.archived_at = Time.zone.now
-    result = save
-    versions.destroy_all if result
-    result
+    save & versions.destroy_all
   end
 
   def archived?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,8 +184,9 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.last_name = id
     self.login_enabled = false
     self.archived_at = Time.zone.now
-    save
-    versions.destroy_all
+    result = save
+    versions.destroy_all if result
+    result
   end
 
   def archived?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -184,8 +184,8 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.last_name = id
     self.login_enabled = false
     self.archived_at = Time.zone.now
-    versions.destroy_all
     save
+    versions.destroy_all
   end
 
   def archived?


### PR DESCRIPTION
### Summary
Because the papertrail is first deleted and then the user is archived, the archiving of the user is still in the papertrail. This PR fixes that.
