### PR TITLE
Increase max image pixel size

### DIFF
--- a/app/uploaders/application_image_uploader.rb
+++ b/app/uploaders/application_image_uploader.rb
@@ -1,6 +1,10 @@
 class ApplicationImageUploader < ApplicationUploader
   process resize_to_limit: [2048, 2048]
 
+  def max_pixel_dimensions
+    [8192, 8192]
+  end
+
   def extension_allowlist
     %w[jpg jpeg png]
   end

--- a/spec/requests/v1/photo_albums_controller/dropzone_spec.rb
+++ b/spec/requests/v1/photo_albums_controller/dropzone_spec.rb
@@ -31,7 +31,7 @@ describe V1::PhotoAlbumsController do
         end
 
         it { expect(request.status).to eq(422) }
-        it { expect(request.body).to eq 'Afbeelding mag niet groter zijn dan 4096 x 4096' }
+        it { expect(request.body).to eq 'Afbeelding mag niet groter zijn dan 8192 x 8192' }
       end
     end
   end


### PR DESCRIPTION
### Summary
Currently, the maximum image size is 4096x4096. Assuming a 4:3 aspect ratio image, this allows for a ~12.5 megapixel image. However, many modern camera's have a larger megapixel count than this. Because of this, the user has to preprocess all the images and resize them to <= 4096x4096 pixels before uploading them. This is not very user friendly. This PR increases the maximum upload size to 8192x8192, allowing for up to ~50 megapixel images to be uploaded. After uploading, the image is already resized automatically to a maximum of 2048x2048 pixels.

Fixes #247 
