### PR TITLE
Implement cleanup job for softdeleted items

### DIFF
--- a/app/jobs/soft_delete_cleanup_job.rb
+++ b/app/jobs/soft_delete_cleanup_job.rb
@@ -1,0 +1,19 @@
+class SoftDeleteCleanupJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    models.each do |model|
+      next unless model.respond_to?(:only_deleted)
+      next unless model.table_name
+
+      records = model.only_deleted.where('deleted_at < ?', 2.years.ago)
+      records.map(&:really_destroy!)
+    end
+  end
+
+  private
+
+  def models
+    ActiveRecord::Base.descendants
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,6 +8,8 @@
 schedule:
   UserCleanupJob:
     cron: '0 9 1 * *'  # At 09:00:00 on each first of the month => https://crontab.guru/#0_9_1_*_*
+  SoftDeleteCleanupJob:
+    cron: '0 9 1 * *'  # At 09:00:00 on each first of the month => https://crontab.guru/#0_9_1_*_*
   cleanup_expired_stored_mails:
     cron: '0 0 9 * * *'   # Runs every day at 9AM
     class: CleanupExpiredStoredMailsJob

--- a/spec/jobs/soft_delete_cleanup_job.rb
+++ b/spec/jobs/soft_delete_cleanup_job.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe SoftDeleteCleanupJob, type: :job do
+  describe '#perform' do
+    subject(:job) { described_class.perform_now }
+
+    let(:record) { FactoryBot.create(:activity) }
+    let(:destroyed_record) { FactoryBot.create(:activity, deleted_at: 1.day.ago) }
+    let(:old_record) { FactoryBot.create(:activity, deleted_at: 2.years.ago) }
+
+    before do
+      record
+      destroyed_record
+      old_record
+    end
+
+    it { expect { job }.not_to change(Activity, :count) }
+    it { expect { job }.to change(Activity.with_deleted, :count).by(-1) }
+  end
+end


### PR DESCRIPTION
### Summary
Currently soft deleted items are still in the database until forever. This could give issues if we ever have a databreach or something like that, and we really don't need the data after a long time. This PR implements a job that will really destroy those entities after 2 year.

@wilco375 could you create a healthcheck job for it? I cannot access that anymore but would be good to have this monitored