### PR TITLE
Limit photo album visibility

### DIFF
--- a/app/models/photo_album.rb
+++ b/app/models/photo_album.rb
@@ -9,6 +9,11 @@ class PhotoAlbum < ApplicationRecord
   validates :publicly_visible, inclusion: [true, false]
 
   scope :publicly_visible, (-> { where(publicly_visible: true) })
+  scope :posted_between_or_publicly_visible, (lambda { |start_date, end_date|
+    where(publicly_visible: true)
+      .or(where.not(date: nil).where(date: start_date..end_date))
+      .or(where(date: nil).where(created_at: start_date..end_date))
+  })
 
   def owners
     if group.present?

--- a/app/policies/photo_album_policy.rb
+++ b/app/policies/photo_album_policy.rb
@@ -1,8 +1,14 @@
 class PhotoAlbumPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
-    def resolve
+    def resolve # rubocop:disable Metrics/AbcSize
       if user_can_read?
-        scope
+        membership = user.memberships.joins(:group).where(groups: { name: 'Leden' }).first
+        return scope.publicly_visible if membership.nil?
+
+        scope.posted_between_or_publicly_visible(
+          membership.start_date&.advance(months: -18),
+          membership.end_date&.advance(months: 6)
+        )
       else
         scope.publicly_visible
       end


### PR DESCRIPTION
This PR limits the visibility of photo albums for old members to a timeframe in and around their membership, as discussed in the meeting on 20-09-2021.