### PR TITLE
Fix (deprecation) warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < JSONAPI::ResourceController
-  include Pundit
+  include Pundit::Authorization
 
   before_action :set_paper_trail_whodunnit
   before_action :set_raven_context

--- a/app/models/board_room_presence.rb
+++ b/app/models/board_room_presence.rb
@@ -1,6 +1,4 @@
 class BoardRoomPresence < ApplicationRecord
-  acts_as_paranoid
-
   belongs_to :user
 
   validates :start_time, presence: true

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -25,9 +25,9 @@ module Rack
       req.params['username'].presence if req.path == '/oauth/token'
     end
 
-    self.throttled_response = lambda do |env|
+    self.throttled_responder = lambda do |req|
       now = Time.zone.now
-      match_data = env['rack.attack.match_data']
+      match_data = req.env['rack.attack.match_data']
 
       headers = {
         'X-RateLimit-Limit' => match_data[:limit].to_s,


### PR DESCRIPTION
Fixes the following warnings:
- `[DEPRECATION] Rack::Attack.throttled_response is deprecated. Please use Rack::Attack.throttled_responder instead`
- `[WARN] BoardRoomPresence is calling acts_as_paranoid more than once!`
- `DEPRECATION WARNING: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.`
