### PR TITLE
Update user allow_tomato_sharing when authorized

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -37,4 +37,16 @@ Doorkeeper.configure do # rubocop:disable Metrics/BlockLength
   resource_owner_authenticator do
     User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
   end
+
+  after_successful_authorization do |controller, auth|
+    if auth.auth.is_a?(Doorkeeper::OAuth::CodeResponse)
+      is_tomato = auth.auth.pre_auth.scopes.include?('tomato')
+      user = auth.auth.pre_auth.resource_owner
+
+      if is_tomato && !user.allow_tomato_sharing
+        user.allow_tomato_sharing = true
+        user.save!
+      end
+    end
+  end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -38,7 +38,7 @@ Doorkeeper.configure do # rubocop:disable Metrics/BlockLength
     User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
   end
 
-  after_successful_authorization do |controller, auth|
+  after_successful_authorization do |_, auth|
     if auth.auth.is_a?(Doorkeeper::OAuth::CodeResponse)
       is_tomato = auth.auth.pre_auth.scopes.include?('tomato')
       user = auth.auth.pre_auth.resource_owner


### PR DESCRIPTION
### Summary
When the user authorizes an OAuth application, a screen is shown where the user explicitly grants permission for information to be shared with that application (https://github.com/csvalpha/amber-ui/blob/staging/app/templates/oauth/authorize.hbs). However, currently, allow_tomato_sharing is not set to true when the user grants permission for SOFIA. When refreshing users in SOFIA, this user is then not synchronized. This PR fixes that. 

