### PR TITLE
Add ImprovMX logs

### DIFF
--- a/app/controllers/action_mailbox/ingresses/improvmx/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/improvmx/inbound_emails_controller.rb
@@ -28,6 +28,10 @@ module ActionMailbox::Ingresses::Improvmx # rubocop:disable Style/ClassAndModule
       response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
         http.request(request)
       end
+
+      logger.info response.code
+      logger.info response.body
+
       response.body
     end
   end


### PR DESCRIPTION
Sometimes, ImprovMX moderated mails fail to be inserted in the database because the hash of the email is the same as an existing email. I suspect that this is because the ImprovMX server sometimes fails to serve the raw email and some error message gets hashed. This PR adds some extra logging to verify this.