### PR TITLE
Fix spreadsheet currency parsing

### DIFF
--- a/app/models/import/transaction.rb
+++ b/app/models/import/transaction.rb
@@ -61,11 +61,17 @@ module Import
       transactions
     end
 
-    def normalize_amount(amount, description, user)
+    def normalize_amount(amount, description, user) # rubocop:disable Metrics/MethodLength
       return amount if amount.nil?
 
       begin
-        amount = amount.tr(',', '.').tr('-', '0').strip.delete_prefix('€').strip if amount.instance_of?(String)
+        if amount.instance_of?(String)
+          amount = amount.tr(',', '.')
+                         .tr('-', '0')
+                         .strip
+                         .delete_prefix('€')
+                         .strip
+        end
         raise ArgumentError if Float(amount).nil? # test whether string is numeric
 
         amount.to_d

--- a/app/models/import/transaction.rb
+++ b/app/models/import/transaction.rb
@@ -66,11 +66,13 @@ module Import
 
       begin
         if amount.instance_of?(String)
-          amount = amount.tr(',', '.')
-                         .tr('-', '0')
-                         .strip
-                         .delete_prefix('€')
-                         .strip
+          amount = amount.strip()
+                         .tr(',', '.')
+                         .tr(' ', '')
+          amount = "0" if amount == '€-'
+          amount = amount.tr('€', '')
+                         .delete_suffix('-')
+                         .delete_suffix('.')
         end
         raise ArgumentError if Float(amount).nil? # test whether string is numeric
 

--- a/app/models/import/transaction.rb
+++ b/app/models/import/transaction.rb
@@ -66,10 +66,10 @@ module Import
 
       begin
         if amount.instance_of?(String)
-          amount = amount.strip()
+          amount = amount.strip
                          .tr(',', '.')
                          .tr(' ', '')
-          amount = "0" if amount == '€-'
+          amount = '0' if amount == '€-'
           amount = amount.tr('€', '')
                          .delete_suffix('.-')
         end

--- a/app/models/import/transaction.rb
+++ b/app/models/import/transaction.rb
@@ -65,7 +65,7 @@ module Import
       return amount if amount.nil?
 
       begin
-        amount = amount.tr(',', '.') if amount.instance_of?(String)
+        amount = amount.tr(',', '.').tr('-', '0').strip.delete_prefix('€').strip if amount.instance_of?(String)
         raise ArgumentError if Float(amount).nil? # test whether string is numeric
 
         amount.to_d

--- a/app/models/import/transaction.rb
+++ b/app/models/import/transaction.rb
@@ -71,8 +71,7 @@ module Import
                          .tr(' ', '')
           amount = "0" if amount == '€-'
           amount = amount.tr('€', '')
-                         .delete_suffix('-')
-                         .delete_suffix('.')
+                         .delete_suffix('.-')
         end
         raise ArgumentError if Float(amount).nil? # test whether string is numeric
 

--- a/spec/support/files/collection_import.csv
+++ b/spec/support/files/collection_import.csv
@@ -1,2 +1,2 @@
 username,Declaraties,Slot BBQ,Slot BBQ Streeplijst,Zeilweek,Voorschot Zeilweek,Gratis Activiteit,Komma,Komma Seperated
-bestuurder,-10,5,2.18,212.5,-100,0,,"2,55"
+bestuurder,-10,5,2.18,212.5,-100,€ -,,"€2,55"

--- a/spec/support/files/collection_import_with_incorrect_transactions.csv
+++ b/spec/support/files/collection_import_with_incorrect_transactions.csv
@@ -1,2 +1,2 @@
 username,Declaraties,Slot BBQ,Slot BBQ Streeplijst,Zeilweek,Voorschot Zeilweek,
-bestuurder,-10,€5,2.18,212.5,-100,2
+bestuurder,-10,tekst,2.18,212.5,-100,2


### PR DESCRIPTION
Fixes #356 

The parser can now handle many currency formats such as:
€ -
€ 1
€ 1,00
-€ 1,00
€ -1,00
€ 1,-
And all of the above without the euro sign, and with a period as decimal separator instead of comma