### PR TITLE
Add job for incoming emails

### DIFF
--- a/app/controllers/action_mailbox/ingresses/improvmx/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/improvmx/inbound_emails_controller.rb
@@ -6,33 +6,15 @@ module ActionMailbox::Ingresses::Improvmx # rubocop:disable Style/ClassAndModule
     before_action :authenticate_by_password
 
     def create
-      ActionMailbox::InboundEmail.create_and_extract_message_id! raw_email
-    end
-
-    private
-
-    def raw_email
       # Email is in the raw parameter in BASE64,
       # unless it is too large then it needs to be retrieved
-      return Base64.decode64(params.require(:raw)) if params.key?(:raw)
-
-      retrieve_email(params.require('raw_url'))
-    end
-
-    def retrieve_email(url) # rubocop:disable Metrics/AbcSize
-      uri = URI(url)
-
-      request = Net::HTTP::Get.new uri
-      request.basic_auth 'api', Rails.application.config.x.improvmx_api_key
-
-      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
-        http.request(request)
+      if params.key?(:raw)
+        raw_email = Base64.decode64(params.require(:raw))
+        ActionMailbox::InboundEmail.create_and_extract_message_id! raw_email
+      else
+        # Create a job to retrieve the email since it may not be available yet at the given url
+        MailModerationCreationJob.set(wait: 1.minute).perform_later(params.require('raw_url'))
       end
-
-      logger.info response.code
-      logger.info response.body
-
-      response.body
     end
   end
 end

--- a/app/jobs/mail_moderation_creation_job.rb
+++ b/app/jobs/mail_moderation_creation_job.rb
@@ -14,7 +14,9 @@ class MailModerationCreationJob < ApplicationJob
     request.basic_auth 'api', Rails.application.config.x.improvmx_api_key
 
     response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      # :nocov:
       http.request(request)
+      # :nocov:
     end
 
     if response.is_a? Net::HTTPSuccess

--- a/app/jobs/mail_moderation_creation_job.rb
+++ b/app/jobs/mail_moderation_creation_job.rb
@@ -1,0 +1,26 @@
+class MailModerationCreationJob < ApplicationJob
+  queue_as :mail_handlers
+
+  def perform(raw_url)
+    ActionMailbox::InboundEmail.create_and_extract_message_id! retrieve_email(raw_url)
+  end
+
+  private
+
+  def retrieve_email(url) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    uri = URI(url)
+
+    request = Net::HTTP::Get.new uri
+    request.basic_auth 'api', Rails.application.config.x.improvmx_api_key
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(request)
+    end
+
+    if response.is_a? Net::HTTPSuccess
+      response.body
+    else
+      raise "Improvmx API returned #{response.code} #{response.message}"
+    end
+  end
+end

--- a/spec/jobs/mail_moderation_creation_job_spec.rb
+++ b/spec/jobs/mail_moderation_creation_job_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe MailModerationCreationJob, type: :job do
+  let(:raw_url) { 'https://example.com/raw_email' }
+  let(:response_body) { 'raw_email_data' }
+  let(:response) do
+    instance_double(Net::HTTPResponse, code: '200', message: 'OK', body: response_body)
+  end
+
+  describe '#perform' do
+    it 'creates and extracts message ID from inbound email' do # rubocop:disable RSpec/ExampleLength
+      allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+      allow(Net::HTTP).to receive(:start).and_return(response)
+
+      allow(ActionMailbox::InboundEmail).to receive(:create_and_extract_message_id!)
+
+      described_class.perform_now(raw_url)
+
+      expect(ActionMailbox::InboundEmail).to have_received(:create_and_extract_message_id!)
+        .with(response_body)
+    end
+
+    it 'raises an error when the client does not return a 200 HTTP response' do
+      response = instance_double(Net::HTTPResponse, code: '404', message: 'Not Found',
+                                                    body: 'raw_email_not_found')
+      allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+      allow(Net::HTTP).to receive(:start).and_return(response)
+      expect { described_class.perform_now(raw_url) }.to raise_error(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
Sometimes, a stored mail would not be stored for an incoming email. This is because the email might not be available yet at the raw_url at the moment the webhook is called. This PR moves the creation of the inbound mail to a job which is executed with a small delay, and will retry if it fails.  