### PR TITLE
Fix name of archived user

### DIFF
--- a/app/jobs/user_archive_job.rb
+++ b/app/jobs/user_archive_job.rb
@@ -21,8 +21,8 @@ class UserArchiveJob < ApplicationJob
     User.create!(id: ARCHIVE_USER_ID,
                  username: 'archived.user',
                  email: 'ict@csvalpha.nl',
-                 first_name: 'Gearchiveerde Gebruiker',
-                 last_name: '-',
+                 first_name: 'Gearchiveerde',
+                 last_name: 'Gebruiker',
                  address: 'Onbekend',
                  postcode: 'Onbekend',
                  city: 'Onbekend')


### PR DESCRIPTION
Since names are shown in the front-end as full_name = first_name + last_name, the archived user was shown as 'Gearchiveerde Gebruiker -'. This PR updates the name of the archived user to 'Gearchiveerde Gebruiker'.
I have already manually updated the name via the `rails console` on the site so this PR is purely administrative / for consistency.