### PR TITLE
Add filter for albums without photos that have tags

### DIFF
--- a/app/models/photo_album.rb
+++ b/app/models/photo_album.rb
@@ -10,7 +10,7 @@ class PhotoAlbum < ApplicationRecord
 
   scope :publicly_visible, (-> { where(publicly_visible: true) })
 
-  scope :without_photo_tags, -> {
+  scope :without_photo_tags, lambda {
     where.not(id: Photo.joins(:tags).select(:photo_album_id).distinct)
   }
 

--- a/app/models/photo_album.rb
+++ b/app/models/photo_album.rb
@@ -10,6 +10,10 @@ class PhotoAlbum < ApplicationRecord
 
   scope :publicly_visible, (-> { where(publicly_visible: true) })
 
+  scope :without_photo_tags, -> {
+    where.not(id: Photo.joins(:tags).select(:photo_album_id).distinct)
+  }
+
   def owners
     if group.present?
       group.active_users + [author]

--- a/app/resources/v1/photo_album_resource.rb
+++ b/app/resources/v1/photo_album_resource.rb
@@ -1,6 +1,8 @@
 class V1::PhotoAlbumResource < V1::ApplicationResource
   attributes :title, :date, :publicly_visible
 
+  filter :without_photo_tags, apply: ->(records, _value, _options) { records.without_photo_tags }
+
   has_many :photos
   has_one :author, always_include_linkage_data: true
   has_one :group, always_include_linkage_data: true


### PR DESCRIPTION
### Summary
Adds a filter for photo albums that only returns albums in which all photos are without tags.
