### PR TITLE
Fix user archival

### DIFF
--- a/app/jobs/user_archive_job.rb
+++ b/app/jobs/user_archive_job.rb
@@ -33,7 +33,18 @@ class UserArchiveJob < ApplicationJob
       key = entity_key(entity)
       records = entity.where({ key => user })
 
-      records.each { |r| r.update({ key => global_archive_user }) && r.versions.destroy_all }
+      migrate_keep_entity_records(key, records)
+    end
+  end
+
+  def migrate_keep_entity_records(key, records)
+    records.each do |r|
+      unless r.update({ key => global_archive_user })
+        raise ActiveRecord::RecordInvalid.new(r),
+              "Failed to update #{r.class} record (ID: #{r.id})"
+      end
+
+      r.versions.destroy_all
     end
   end
 

--- a/app/models/form/response.rb
+++ b/app/models/form/response.rb
@@ -8,7 +8,7 @@ module Form
     has_many :closed_question_answers, dependent: :destroy
     has_many :closed_questions, through: :closed_question_answers, source: :question
 
-    validates :user, uniqueness: { scope: :form }
+    validates :user, uniqueness: { scope: :form, unless: -> { user_id.zero? } }
     validate :form_allows_responses?
 
     after_create :update_completed_status!

--- a/app/models/form/response.rb
+++ b/app/models/form/response.rb
@@ -8,7 +8,7 @@ module Form
     has_many :closed_question_answers, dependent: :destroy
     has_many :closed_questions, through: :closed_question_answers, source: :question
 
-    validates :user, uniqueness: { scope: :form, unless: -> { user_id.zero? } }
+    validates :user, uniqueness: { scope: :form, unless: -> { !user.id.nil? && user.id.zero? } }
     validate :form_allows_responses?
 
     after_create :update_completed_status!

--- a/app/models/form/response.rb
+++ b/app/models/form/response.rb
@@ -8,7 +8,7 @@ module Form
     has_many :closed_question_answers, dependent: :destroy
     has_many :closed_questions, through: :closed_question_answers, source: :question
 
-    validates :user, uniqueness: { scope: :form, unless: -> { !user.id.nil? && user.id.zero? } }
+    validates :user, uniqueness: { scope: :form, unless: -> { !user.nil? && !user.id.nil? && user.id.zero? } }
     validate :form_allows_responses?
 
     after_create :update_completed_status!

--- a/app/models/form/response.rb
+++ b/app/models/form/response.rb
@@ -8,7 +8,7 @@ module Form
     has_many :closed_question_answers, dependent: :destroy
     has_many :closed_questions, through: :closed_question_answers, source: :question
 
-    validates :user, uniqueness: { scope: :form, unless: -> { user_id.zero? } }
+    validates :user, uniqueness: { scope: :form, unless: -> { user_id == 0 } }
     validate :form_allows_responses?
 
     after_create :update_completed_status!

--- a/app/models/form/response.rb
+++ b/app/models/form/response.rb
@@ -8,7 +8,9 @@ module Form
     has_many :closed_question_answers, dependent: :destroy
     has_many :closed_questions, through: :closed_question_answers, source: :question
 
-    validates :user, uniqueness: { scope: :form, unless: -> { !user.nil? && !user.id.nil? && user.id.zero? } }
+    validates :user, uniqueness: { scope: :form, unless: lambda {
+                                                           !user.nil? && !user.id.nil? && user.id.zero?
+                                                         } }
     validate :form_allows_responses?
 
     after_create :update_completed_status!

--- a/app/models/form/response.rb
+++ b/app/models/form/response.rb
@@ -8,7 +8,7 @@ module Form
     has_many :closed_question_answers, dependent: :destroy
     has_many :closed_questions, through: :closed_question_answers, source: :question
 
-    validates :user, uniqueness: { scope: :form, unless: -> { user_id == 0 } }
+    validates :user, uniqueness: { scope: :form, unless: -> { user_id.zero? } }
     validate :form_allows_responses?
 
     after_create :update_completed_status!

--- a/app/models/form/response.rb
+++ b/app/models/form/response.rb
@@ -8,9 +8,7 @@ module Form
     has_many :closed_question_answers, dependent: :destroy
     has_many :closed_questions, through: :closed_question_answers, source: :question
 
-    validates :user, uniqueness: { scope: :form, unless: lambda {
-                                                           !user.nil? && !user.id.nil? && user.id.zero?
-                                                         } }
+    validates :user, uniqueness: { scope: :form, unless: -> { user_id == 0 } } # rubocop:disable Style/NumericPredicate
     validate :form_allows_responses?
 
     after_create :update_completed_status!

--- a/spec/models/form/response_spec.rb
+++ b/spec/models/form/response_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe Form::Response, type: :model do
       it { expect(another_response).not_to be_valid }
     end
 
+    context 'when the user is archived' do
+      let(:archived_user) { create(:user, id: 0) }
+      let(:another_response) do
+        build(:response, form: form, user: archived_user)
+      end
+      let(:form) { create(:form) }
+
+      before do
+        create(:response, form: form, user: archived_user)
+      end
+
+      it 'allows multiple responses' do
+        expect(another_response).to be_valid
+      end
+    end
+
     context 'when form is not published' do
       before do
         response.form.update(respond_from: 2.days.ago, respond_until: Date.yesterday)


### PR DESCRIPTION
### Summary
Fixes #428

User archival failed because a form can only have one response per user, but if multiple responses are archived they all get user id 0, which caused this validation to fail. The validation now explicitly excludes the archived user (id 0). 
I also changed the user update statement to throw an error once an update fails. This makes it more clear where the error occurs. Regardless of this, user archival will fail anyways if the update fails because of foreign key constraints once the user is attempted to be deleted (as has been happening until now). 