### PR TITLE
Fix photo soft delete archival

### DIFF
--- a/app/policies/photo_policy.rb
+++ b/app/policies/photo_policy.rb
@@ -2,9 +2,9 @@ class PhotoPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
       if user_can_read?
-        scope.includes(:photo_album)
+        scope
       else
-        scope.publicly_visible.includes(:photo_album)
+        scope.publicly_visible
       end
     end
   end

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -8,6 +8,6 @@ class PhotoUploader < ApplicationImageUploader
   end
 
   def store_dir
-    "uploads/photo_albums/#{model.photo_album.id}/photos/#{model.id}"
+    "uploads/photo_albums/#{model.photo_album_id}/photos/#{model.id}"
   end
 end


### PR DESCRIPTION
### Summary
This fixes the soft delete archival job.
If the photo album is deleted before the photo, the modified code caused a `undefined method 'id' for nil:NilClass` error, because `model.photo_album` no longer exists and returns `nil`. This seems to be the only thing that caused the SoftDeleteCleanupJob to fail. However, there might be more similar issues in our code, so let's keep an eye on the Job. 

As a more robust solution we could add cascades to the foreign keys, but we should be VERY careful that this does not cause data to be deleted that should not be deleted (e.g. in the current state of user archival without #434 merged, this would have deleted all models for which the user id failed to update once `user.really_destroy!` is called)