### PR TITLE
Fixed the error CD gives

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,9 +12,13 @@ on:
         required: false
         type: string
     secrets:
+      codecov_token:
+        description: Codecov token
+        required: true
       rails_master_key:
         description: The Rails master key
         required: true
+ 
 
 jobs:
   build:


### PR DESCRIPTION
Due to a commit https://github.com/csvalpha/amber-api/commit/5dfd9b9992cd4583222f183f952540090657ea44 the workflow on master is broken. this is the case because CD runs CI and gives the codecov token as one of the arguments. however CI doesn't know what to do with this and crashes.