### PR TITLE
Fix for automatic mails being broken

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ POSTGRES_PASSWORD=<password>
 HOST=csvalpha.nl
 
 NGROK_HOST=<subdomain>.ngrok.io
+
+NOREPLY_EMAIL=no-reply@development.csvalpha.nl
+ICT_EMAIL=ict@development.csvalpha.nl
+PRIVACY_EMAIL=privacy@development.csvalpha.nl
+ADMIN_EMAIL=mailbeheer@development.csvalpha.nl

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,9 +82,9 @@ module Amber
 
     config.x.healthcheck_ids = credentials.dig(Rails.env.to_sym, :healthcheck_ids)
 
-    config.x.noreply_email = ENV.fetch('NOREPLY_EMAIL', 'no-reply@csvalpha.com')
-    config.x.ict_email = ENV.fetch('ICT_EMAIL', 'ict@csvalpha.com')
-    config.x.privacy_email = ENV.fetch('PRIVACY_EMAIL', 'privacy@csvalpha.com')
-    config.x.mailbeheer_email = ENV.fetch('PRIVACY_EMAIL', 'mailbeheer@csvalpha.com')
+    config.x.noreply_email = ENV.fetch('NOREPLY_EMAIL', 'no-reply@csvalpha.nl')
+    config.x.ict_email = ENV.fetch('ICT_EMAIL', 'ict@csvalpha.nl')
+    config.x.privacy_email = ENV.fetch('PRIVACY_EMAIL', 'privacy@csvalpha.nl')
+    config.x.mailbeheer_email = ENV.fetch('MAILADMIN_EMAIL', 'mailbeheer@csvalpha.nl')
   end
 end


### PR DESCRIPTION
https://github.com/csvalpha/amber-api/pull/460 The mailadresses have been extracted to the config. However they end in .com instead of .nl which breaks all automatic mails.

I also added the emailadresses to the .env file so that in the future when we are using mail in the development environment it has its own adresses