### PR TITLE
Bugfix for enabling smtp when creating a mail alias

### DIFF
--- a/app/models/mail_alias.rb
+++ b/app/models/mail_alias.rb
@@ -13,7 +13,7 @@ class MailAlias < ApplicationRecord
 
   before_validation :downcase_email
 
-  before_save :set_smtp
+  after_save :set_smtp
   before_destroy :disable_smtp
   after_commit :sync_mail_aliases
 

--- a/app/models/mail_alias.rb
+++ b/app/models/mail_alias.rb
@@ -13,8 +13,8 @@ class MailAlias < ApplicationRecord
 
   before_validation :downcase_email
 
-  after_save :set_smtp
   before_destroy :disable_smtp
+  after_save :set_smtp
   after_commit :sync_mail_aliases
 
   scope :mail_aliases_moderated_by_user, (lambda { |user|


### PR DESCRIPTION
Fixes https://github.com/csvalpha/amber-api/issues/374

We tried to call the enabltesmtp job before the record was created thus no id could be provided to the job.
