### PR TITLE
Split words before searching v2

### DIFF
--- a/app/resources/v1/application_resource.rb
+++ b/app/resources/v1/application_resource.rb
@@ -37,16 +37,17 @@ class V1::ApplicationResource < JSONAPI::Resource
   end
 
   def self.search(records, value)
-    return records if records == []
-
-    final_records = []
+    return records if records.empty?
+  
     arel = records.first.class.arel_table
     value.each do |val|
-      searchable_fields.each do |field|
-        final_records << records.where(arel[field].lower.matches("%#{val.downcase}%"))
+      val.split.each do |word|
+        records = records.where(
+          searchable_fields.map { |field| arel[field].lower.matches("%#{word.downcase}%") }.inject(:or)
+        )
       end
-    end
-    records.where(id: final_records.flatten.map(&:id))
+    end  
+    records
   end
 
   def self.records(options = {})

--- a/app/resources/v1/application_resource.rb
+++ b/app/resources/v1/application_resource.rb
@@ -36,9 +36,9 @@ class V1::ApplicationResource < JSONAPI::Resource
     end
   end
 
-  def self.search(records, value)
+  def self.search(records, value) # rubocop:disable Metrics/MethodLength
     return records if records.empty?
-  
+
     arel = records.first.class.arel_table
     value.each do |val|
       val.split.each do |word|
@@ -46,7 +46,7 @@ class V1::ApplicationResource < JSONAPI::Resource
           searchable_fields.map { |field| arel[field].lower.matches("%#{word.downcase}%") }.inject(:or)
         )
       end
-    end  
+    end
     records
   end
 


### PR DESCRIPTION
fixes https://github.com/csvalpha/amber-api/issues/194
I looked at https://github.com/csvalpha/amber-api/pull/196 for inspiration.

This PR make sure that when you search for first_name + last_name it return only the users that fit both searches word

when using the same/similar words twice it works suboptimal 

